### PR TITLE
Fix relaypriority calculation error

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -188,8 +188,8 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight)
     {
         const CCoins &coins = GetCoins(txin.prevout.hash);
         if (!coins.IsAvailable(txin.prevout.n)) continue;
-        if (coins->nHeight <= nHeight) {
-            dResult += (double)(coins.vout[txin.prevout.n].nValue) * (nHeight-coins->nHeight);
+        if (coins.nHeight <= nHeight) {
+            dResult += (double)(coins.vout[txin.prevout.n].nValue) * (nHeight-coins.nHeight);
         }
     }
     return tx.ComputePriority(dResult);


### PR DESCRIPTION
reverting this accidental commit. 
https://github.com/FeatherCoin/Feathercoin/commit/cc6020bef479aeee8d1fe427620b1fddecae1d62

during build you'll get this error: 
2 warnings generated.
  CXX      coins.o
coins.cpp:191:18: error: member reference type 'const CCoins' is not a pointer; did you mean to use '.'?
        if (coins->nHeight <= nHeight) {
            ~~~~~^~
                 .
coins.cpp:192:84: error: member reference type 'const CCoins' is not a pointer; did you mean to use '.'?
            dResult += (double)(coins.vout[txin.prevout.n].nValue) * (nHeight-coins->nHeight);
                                                                              ~~~~~^~
                                                                                   .
