### PR TITLE
Generalise the FTC readme to 0.9.6.x as current release line

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Feathercoin Core integration/staging tree
 Feathercoin Core
 ================
 
-Status 0.9.3.6
---------------
- production release 
+Status - Feathercoin 0.9.6.x  production release version line.
+--------------------------------------------------------------
+
 
 What is Feathercoin?
 --------------------


### PR DESCRIPTION
Minor update to Readme.md - to increment the general  Version line to 0.9.6.x   (to differentiate fully from : from versions 0.9.1.x to 0.9.3.x)  