### PR TITLE
Bug fix https://github.com/litecoin-project/litecoin/issues/247

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -239,7 +239,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);
         if (!coins->IsAvailable(txin.prevout.n)) continue;
-        if (coins->nHeight < nHeight) {
+        if (coins->nHeight <= nHeight) {
             dResult += coins->vout[txin.prevout.n].nValue * (nHeight-coins->nHeight);
         }
     }


### PR DESCRIPTION
Fixes FTC issue
coins.cpp review #140 
if (coins->nHeight <= nHeight)

Re issue(bitcoin#8334) in bitcoin ,and this also effect litecoin
relaypriority calculation error
CCoinsViewCache::GetPriority has an overflow bug that affects the relaypriority calculation.
The way the arithmetic works in that function is
dResult += coins->vout[txin.prevout.n].nValue * (nHeight-coins->nHeight); 
the nValue variable type is int64_t, and the int64_t max value is 9223372036854775807
for example
nValue value  is 40000000000000
(nHeight->coins - nHeight )value is 300000 
40000000000000 * 300000 > 9223372036854775807 

so the dResult will be negative number!
and the AllowFree function will return False, and the high priority transaction with low fee will be reject by node with error insufficient priority!
I found this bug when I send a transaction with rpc api sendrawtransaction,i debug the source code find it.
and int64_t convert double also will loss accuracy!