### PR TITLE
0.9.6.2 sync debug message review - remove some superflous messages,

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1468,10 +1468,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         bnNew = Params().ProofOfWorkLimit();
 
     /// debug print
-    LogPrintf("GetNextWorkRequired RETARGET\n");
-    LogPrintf("nTargetTimespan = %d    nActualTimespan = %d\n", nTargetTimespan, nActualTimespan);
-    LogPrintf("Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString());
-    LogPrintf("After:  %08x  %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString());
+    // LogPrintf("GetNextWorkRequired RETARGET\n");
+    // LogPrintf("nTargetTimespan = %d    nActualTimespan = %d\n", nTargetTimespan, nActualTimespan);
+    // LogPrintf("Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString());
+    // LogPrintf("After:  %08x  %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString());
 
     return bnNew.GetCompact();
 }
@@ -1486,6 +1486,9 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
         return error("CheckProofOfWork() : nBits below minimum work");
 
     // Check proof of work matches claimed amount
+    LogPrintf("CheckProofOfWork() hash=%s \n",hash.ToString().c_str());
+    LogPrintf("CheckProofOfWork() nBits=%i \n",nBits);
+    LogPrintf("CheckProofOfWork() bnTarget.getuint256=%s \n",bnTarget.getuint256().ToString().c_str());
     if (hash > bnTarget.getuint256())
         return error("CheckProofOfWork() : hash doesn't match nBits");
 
@@ -2718,7 +2721,6 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, int nH
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash(), block.nBits))
     	return state.DoS(50, error("CheckBlockHeader(),block.CheckProofOfWork : proof of work failed."),
                          REJECT_INVALID, "high-hash");
-
     // Check timestamp
     if (block.GetBlockTime() > GetAdjustedTime() + 2 * 60 * 60)
         return state.Invalid(error("CheckBlockHeader() : block timestamp too far in the future"),


### PR DESCRIPTION
correct \n", reinstate an error message. Add (fDebug) to
superfluous tip debug message, can be useful to know height when debugging.