### PR TITLE
ACP service bit to toggle CHECKPOINT messages

### DIFF
--- a/src/checkpointsync.cpp
+++ b/src/checkpointsync.cpp
@@ -151,7 +151,8 @@ bool AcceptPendingSyncCheckpoint()
         if (!checkpointMessage.IsNull())
         {
             g_connman->ForEachNode([](CNode* pnode) {
-                checkpointMessage.RelayTo(pnode);
+                if (pnode->supportACPMessages)
+                    checkpointMessage.RelayTo(pnode);
             });
         }
 

--- a/src/checkpointsync.h
+++ b/src/checkpointsync.h
@@ -115,7 +115,7 @@ public:
         const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
 
         // returns true if wasn't already sent
-        if (pfrom->hashCheckpointKnown != hashCheckpoint)
+        if (pfrom->hashCheckpointKnown != hashCheckpoint && pfrom->supportACPMessages)
         {
             CConnman& connman = *g_connman;
             pfrom->hashCheckpointKnown = hashCheckpoint;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1168,6 +1168,10 @@ bool AppInitParameterInteraction()
         if (!SetCheckpointPrivKey(gArgs.GetArg("-checkpointkey", "")))
             return InitError(_("Unable to sign checkpoint, wrong checkpointkey?"));
     }
+
+    // Include NODE_ACP in services. Currently no arg to toggle this behaviour.
+    nLocalServices = ServiceFlags(nLocalServices | NODE_ACP);
+
     return true;
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2741,6 +2741,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseRecv = false;
     fPauseSend = false;
     nProcessQueueSize = 0;
+    supportACPMessages = false;
 
     for (const std::string &msg : getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -676,7 +676,8 @@ public:
     std::set<uint256> setKnown;
     int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
-	uint256 hashCheckpointKnown;
+    uint256 hashCheckpointKnown;
+    bool supportACPMessages;
 
     // inventory based relay
     CRollingBloomFilter filterInventoryKnown;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1654,6 +1654,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             State(pfrom->GetId())->fHaveWitness = true;
         }
 
+        if((nServices & NODE_ACP))
+            pfrom->supportACPMessages = true;
+
         // Potentially mark this peer as a preferred download peer.
         {
         LOCK(cs_main);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -279,6 +279,11 @@ enum ServiceFlags : uint64_t {
     // serving the last 288 (2 day) blocks
     // See BIP159 for details on how this is implemented.
     NODE_NETWORK_LIMITED = (1 << 10),
+    // NODE_ACP means the node supports Automatic Checkpointing
+    // If this is turned off then the node will not receive checkpoints from other nodes aware of this
+    // flag. Bit 24 from the start of the experimental range has been set for this Feathercoin feature
+    // to not clash with Bitcoin's future developments.
+    NODE_ACP = (1 << 24),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -902,8 +902,8 @@ QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
 
-    // Just scan the last 8 bits for now.
-    for (int i = 0; i < 8; i++) {
+    // Just scan the last 25 bits for now.
+    for (int i = 0; i < 25; i++) {
         uint64_t check = 1 << i;
         if (mask & check)
         {
@@ -911,6 +911,11 @@ QString formatServicesStr(quint64 mask)
             {
             case NODE_NETWORK:
                 strList.append("NETWORK");
+                break;
+            // Bitcoin normally checks 8 bits but due to ACP using a bit in the experimental range as designated 
+            // by Bitcoin, Feathercoin has extended the check to 25 bits which now includes the previously exluded
+            // NODE_NETWORK_LIMITED using bit 10 which shows as UNKNOWN unless handled here.
+            case NODE_NETWORK_LIMITED:
                 break;
             case NODE_GETUTXO:
                 strList.append("GETUTXO");
@@ -923,6 +928,9 @@ QString formatServicesStr(quint64 mask)
                 break;
             case NODE_XTHIN:
                 strList.append("XTHIN");
+                break;
+            case NODE_ACP:
+                strList.append("ACP");
                 break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));


### PR DESCRIPTION
This adds a service bit to indicate that the node supports ACP (Automatic Checkpointing), if that service bit is not present then the CHECKPOINT messages are not sent to that node. This helps compatibility with alternative clients that do not support CHECKPOINT  messages.

Service bit 24 was chosen as this is in the experimental bit range designated by Bitcoin so should not clash with any additional service bits put into production by Bitcoin.