### PR TITLE
Add nNeoScryptOptions to profile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,12 +193,6 @@ if test "x$use_asm" = xyes; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
 fi
 
-AC_ARG_ENABLE([sse2],
-  [AC_HELP_STRING([--enable-sse2],
-  [enable SSE2 optimizations (defaults is yes)])],
-  [use_sse2=${enableval}],
-  [use_sse2=yes])
-
 AC_ARG_WITH([system-univalue],
   [AS_HELP_STRING([--with-system-univalue],
   [Build with system UniValue (default is no)])],
@@ -550,11 +544,6 @@ fi
 
 if test x$use_lcov_branch != xno; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
-fi
-
-if test "$use_sse2" = "yes"; then
-    AX_CHECK_COMPILE_FLAG([-msse2],[CFLAGS="$CFLAGS -msse2" && CXXFLAGS="$CXXFLAGS -msse2"])
-    AC_DEFINE([USE_SSE2],[1],[Define if SSE2 support should be compiled in])
 fi
 
 dnl Check for endianness
@@ -1269,7 +1258,6 @@ AM_CONDITIONAL([ENABLE_QT],[test x$bitcoin_enable_qt = xyes])
 AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
 AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])
 AM_CONDITIONAL([USE_QRCODE], [test x$use_qr = xyes])
-AM_CONDITIONAL([USE_SSE2], [test x$use_sse2 = xyes])
 AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
@@ -1319,7 +1307,6 @@ AC_SUBST(SSE42_CXXFLAGS)
 AC_SUBST(LIBTOOL_APP_LDFLAGS)
 AC_SUBST(USE_UPNP)
 AC_SUBST(USE_QRCODE)
-AC_SUBST(USE_SSE2)
 AC_SUBST(BOOST_LIBS)
 AC_SUBST(TESTDEFS)
 AC_SUBST(LEVELDB_TARGET_FLAGS)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -904,7 +904,7 @@ bool AppInitParameterInteraction()
     const CChainParams& chainparams = Params();
     // ********************************************************* Step 2: parameter interactions
 
-#if defined (USE_SSE2)
+#if defined (USE_ASM)
     nNeoScryptOptions |= 0x1000;
 #endif
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -6,10 +6,11 @@
 #include <primitives/block.h>
 
 #include <hash.h>
-#include "crypto/neoscrypt.h"
+#include <crypto/neoscrypt.h>
 #include <tinyformat.h>
 #include <utilstrencodings.h>
 #include <crypto/common.h>
+#include <util.h>
 
 uint256 CBlockHeader::GetHash() const
 {
@@ -20,6 +21,7 @@ uint256 CBlockHeader::GetPoWHash(unsigned int profile) const
 {
     uint256 hash;
 
+    profile |= nNeoScryptOptions;
     neoscrypt((unsigned char *) &nVersion, (unsigned char *) &hash, profile);
 
     return(hash);


### PR DESCRIPTION
Bug reported to Phoenixcoin that nNeoScryptOptions was never added to profile which is passed to neoscrypt as an argument to make use of SSE2 optimisations coded in assembly. 

https://github.com/ghostlander/Phoenixcoin/issues/9

Feathercoin assumes SSE2 support, the Steam Hardware Survey shows SSE2 support at 100%, in 2016 SSE2 support was at 99.9%. Intel added support in 2001 and AMD in 2003.

https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam?platform=combined