### PR TITLE
:arrow_up: updates zeromq `0002-disable-pthread_set_name_np.patch` to v4.3.1

### DIFF
--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,6 +1,6 @@
-From c9bbdd6581d07acfe8971e4bcebe278a3676cf03 Mon Sep 17 00:00:00 2001
-From: mruddy <6440430+mruddy@users.noreply.github.com>
-Date: Sat, 30 Jun 2018 09:57:18 -0400
+From 2192f92e933f94a66dac9a66ea9223f93d630dba Mon Sep 17 00:00:00 2001
+From: Matthew Hartstonge <matt@mykro.co.nz>
+Date: Wed, 27 Feb 2019 00:07:06 +1300
 Subject: [PATCH] disable pthread_set_name_np
 
 pthread_set_name_np adds a Glibc requirement on >= 2.12.
@@ -9,10 +9,10 @@ pthread_set_name_np adds a Glibc requirement on >= 2.12.
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/src/thread.cpp b/src/thread.cpp
-index a1086b0c..9943f354 100644
+index 84473dca..b4acb05b 100644
 --- a/src/thread.cpp
 +++ b/src/thread.cpp
-@@ -307,7 +307,7 @@ void zmq::thread_t::setThreadName (const char *name_)
+@@ -308,7 +308,7 @@ void zmq::thread_t::setThreadName (const char *name_)
   */
      if (!name_)
          return;
@@ -21,9 +21,9 @@ index a1086b0c..9943f354 100644
  #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
      int rc = pthread_setname_np (name_);
      if (rc)
-@@ -323,6 +323,8 @@ void zmq::thread_t::setThreadName (const char *name_)
+@@ -324,6 +324,8 @@ void zmq::thread_t::setThreadName (const char *name_)
  #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
-     pthread_set_name_np (descriptor, name_);
+     pthread_set_name_np (_descriptor, name_);
  #endif
 +#endif
 +    return;


### PR DESCRIPTION
Due to the recent upgrade to ZeroMQ v4.3.1, an additional line has entered `threads.cpp` which, when called upon in certain OS, causes the patch to fail due to not matching the source.

Fixes #374.

Tested against Alpine Linux 3.9 and Debian 9 (stretch).