### PR TITLE
fix for compile problems on Ubuntu 21.04 and other new distributions

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -9,7 +9,7 @@
 #include <QPainter>
 #include <QColor>
 #include <QTimer>
-
+#include <QPainterPath>
 #include <cmath>
 
 #define DESIRED_SAMPLES         800


### PR DESCRIPTION
Feathercoin-qt doesn't compile on ubuntu 21.04 and other newer distributions due to a change in the includes for qt, leading to a missing QPainterPath include

This path fixes that.