### PR TITLE
fix compile problem with Qt5

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <interfaces/node.h>
-#include <qt/trafficgraphwidget.h>
-#include <qt/clientmodel.h>
 
 #include <QPainter>
 #include <QColor>
 #include <QTimer>
 #include <QPainterPath>
 #include <cmath>
+#include <interfaces/node.h>
+#include <qt/trafficgraphwidget.h>
+#include <qt/clientmodel.h>
 
 #define DESIRED_SAMPLES         800
 


### PR DESCRIPTION
In Qt 5  it is required to include QPainterPath in qt/gui/trafficgraphwidget.cpp 
Please create release v0.19.1.1 after merging