### PR TITLE
docs: refresh GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,12 @@
-<!-- This issue tracker is only for technical issues related to Bitcoin Core.
+<!-- This issue tracker is for technical issues related to Feathercoin Core.
 
-General bitcoin questions and/or support requests are best directed to the Bitcoin StackExchange at https://bitcoin.stackexchange.com.
+General Feathercoin questions and support requests are best directed to the community channels linked from https://feathercoin.com/.
 
-For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+Please avoid posting sensitive security details publicly. Contact the maintainers privately before disclosure where possible.
 
 If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running memtest and observe CPU temperature with a load-test tool such as linpack before creating an issue!
 
-Any report, issue or feature request related to the GUI should be reported at
-https://github.com/bitcoin-core/gui/issues/
+GUI reports and feature requests can be reported here with operating system and desktop environment details.
 -->
 
 <!-- Describe the issue -->
@@ -17,7 +16,7 @@ https://github.com/bitcoin-core/gui/issues/
 
 <!--- How reliably can you reproduce the issue, what are the steps to do so? -->
 
-<!-- What version of Bitcoin Core are you using, where did you get it (website, self-compiled, etc)? -->
+<!-- What version of Feathercoin Core are you using, where did you get it (website, self-compiled, etc)? -->
 
 <!-- What type of machine are you observing the error on (OS/CPU and disk type)? -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-<!-- This issue tracker is only for technical issues related to Bitcoin Core.
+<!-- This issue tracker is for technical issues related to Feathercoin Core.
 
-General bitcoin questions and/or support requests are best directed to the Bitcoin StackExchange at https://bitcoin.stackexchange.com.
+General Feathercoin questions and support requests are best directed to the community channels linked from https://feathercoin.com/.
 
-For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+Please avoid posting sensitive security details publicly. Contact the maintainers privately before disclosure where possible.
 
 If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running memtest and observe CPU temperature with a load-test tool such as linpack before creating an issue! -->
 
@@ -31,7 +31,7 @@ If the node is "stuck" during sync or giving "block checksum mismatch" errors, p
 
 **System information**
 
-<!-- What version of Bitcoin Core are you using, where did you get it (website, self-compiled, etc)? -->
+<!-- What version of Feathercoin Core are you using, where did you get it (website, self-compiled, etc)? -->
 
 <!-- What type of machine are you observing the error on (OS/CPU and disk type)? -->
 

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -15,8 +15,8 @@ assignees: ''
 
 #### Useful skills:
 
-<!-- (For example, “C++11 std::thread”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.) -->
+<!-- (For example, “C++11 std::thread”, “Qt5 GUI and async GUI design” or “basic understanding of Feathercoin mining and the Feathercoin Core RPC interface”.) -->
 
 #### Want to work on this issue?
 
-For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.
+For guidance on contributing, please describe the intended change clearly and open a focused pull request against this repository.

--- a/.github/ISSUE_TEMPLATE/gui_issue.md
+++ b/.github/ISSUE_TEMPLATE/gui_issue.md
@@ -1,11 +1,12 @@
 ---
-name: An issue or feature request related to the GUI
-about: Any report, issue or feature request related to the GUI should be reported at https://github.com/bitcoin-core/gui/issues/
-title: Any report, issue or feature request related to the GUI should be reported at https://github.com/bitcoin-core/gui/issues/
+name: GUI issue or feature request
+about: Report an issue or suggest an improvement for the Feathercoin Core GUI
+title: ''
 labels: GUI
 assignees: ''
 
 ---
 
-Any report, issue or feature request related to the GUI should be reported at
-https://github.com/bitcoin-core/gui/issues/
+Please describe the Feathercoin Core GUI issue or feature request here.
+
+Include your operating system, desktop environment, Feathercoin Core version, and screenshots if they help explain the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,13 @@
 Pull requests without a rationale and clear improvement may be closed
 immediately.
 
-GUI-related pull requests should be opened against
-https://github.com/bitcoin-core/gui
-first. See CONTRIBUTING.md
+If this changes GUI behavior, please include screenshots or describe the
+platforms tested.
 -->
 
 <!--
 Please provide clear motivation for your patch and explain how it improves
-Bitcoin Core user experience or Bitcoin Core developer experience
+Feathercoin Core user experience or Feathercoin Core developer experience
 significantly:
 
 * Any test improvements or new tests that improve coverage are always welcome.
@@ -24,7 +23,7 @@ significantly:
   was fixed.
 * Features are welcome, but might be rejected due to design or scope issues.
   If a feature is based on a lot of dependencies, contributors should first
-  consider building the system outside of Bitcoin Core, if possible.
+  consider building the system outside of Feathercoin Core, if possible.
 * Refactoring changes are only accepted if they are required for a feature or
   bug fix or otherwise improve developer experience significantly. For example,
   most "code style" refactoring changes require a thorough explanation why they
@@ -36,8 +35,6 @@ significantly:
 -->
 
 <!--
-Bitcoin Core has a thorough review process and even the most trivial change
-needs to pass a lot of eyes and requires non-zero or even substantial time
-effort to review. There is a huge lack of active reviewers on the project, so
-patches often sit for a long time.
+Feathercoin Core has limited review capacity, so small focused patches with
+clear motivation and testing notes are easiest to review.
 -->


### PR DESCRIPTION
## Summary
- refresh issue and pull request templates that still pointed contributors to Bitcoin Core resources
- update the GUI template so Feathercoin Core GUI reports can be filed in this repository
- remove stale upstream contribution guidance from the good-first-issue template

## Why
Thanks for moving the 0.21 release work forward. I noticed a small contributor-facing cleanup that may reduce confusion for new reports and PRs while the project is active again.

## Testing
- git diff --check
